### PR TITLE
Fixed sign up bug

### DIFF
--- a/src/Components/SignUp/SignUp.js
+++ b/src/Components/SignUp/SignUp.js
@@ -190,7 +190,7 @@ function SignUp(props) {
                     value={state.accountType}
                     onChange={handleChange}
                   >
-                    <option>Choose Service Type</option>
+                    <option value="">Choose Service Type</option>
                     <option>Commercial</option>
                     <option>Residential</option>
                   </Form.Control>
@@ -306,7 +306,7 @@ function SignUp(props) {
                       value={state.accountType}
                       onChange={handleChange}
                     >
-                      <option>Choose Service Type</option>
+                      <option value="">Choose Service Type</option>
                       <option>Commercial</option>
                       <option>Residential</option>
                     </Form.Control>


### PR DESCRIPTION
Fixes a bug where sign up form grabs incorrect account type if user selects one and then switches back to default option. This would lead to a successful sign up without a valid account type. This fix brings up the correct error message and prevents a successful sign up until a valid account type is selected.